### PR TITLE
Bug fixes.

### DIFF
--- a/fludashboard/libs/charts.py
+++ b/fludashboard/libs/charts.py
@@ -87,10 +87,17 @@ def ethio_ts(df=pd.DataFrame, scale_id=int, year=int):
     # X-axis title and range:
     lastepiweek = int(episem(lastepiday(year), out='W'))
     extra_cols.extend(['Testes positivos'])
-    ymax = [
-        max(5*np.ceil(df[extra_cols].max().max()/5), 5),
-        max(5*np.ceil(df[cols[1:]].max().max()/5), 5)
-    ]
+    if scale_id == 2:
+        ymax = [
+            max(5*np.ceil(df[extra_cols].max().max()/5), 5),
+            max(5*np.ceil(df[cols[1:]].max().max()/5), 5)
+        ]
+    else:
+        ymax = [
+            df[extra_cols].max().max(),
+            df[cols[1:]].max().max()
+        ]
+
     for i in range(1, (nrows + 1)):
         xaxis = 'xaxis%s' % i
         yaxis = 'yaxis%s' % i

--- a/fludashboard/libs/flu_data.py
+++ b/fludashboard/libs/flu_data.py
@@ -477,6 +477,7 @@ class FluDB:
                     AND scale_id = %(scale_id)s
                     AND base_epiweek <= %(epiweek)s
                     %(territory_id_condition)s )
+            AND epiyear =%(epiyear)s
             ''' % sql_param
 
         # force week filter (week 0 == all weeks)

--- a/fludashboard/libs/views.py
+++ b/fludashboard/libs/views.py
@@ -471,6 +471,9 @@ def etiological_agents(
     """
     territory_id = fluDB.get_territory_id_from_name(territory_name)
 
+    # Etiological panel fixed to cases scale, not incidence.
+    scale_id = 2
+
     df = FluDB().get_etiological_data(
         dataset_id=dataset_id, scale_id=scale_id, year=year,
         week=epiweek, territory_id=territory_id


### PR DESCRIPTION
- When epiweek was too low, the CI from epiweeks of the previous
epiyear would show on the incidence chart;
- Ethiological panel is now fixed on "cases" scale;
- Fixed inconsistency between contingency levels on calc_flu_chart.py
and flu_map.js;
- Updated contingency calculation to include previous weeks on the same epiyear, since the data is always changing;

TODO:
- Check why on Earth the orange level (contingency=3) on contingency
view is showing as red, even though the color is set to #ff7700