### PR TITLE
Solved #158

### DIFF
--- a/fludashboard/static/js/flu_chart.js
+++ b/fludashboard/static/js/flu_chart.js
@@ -152,7 +152,7 @@ class SRAGIncidenceChart{
     }
     $('#chart-incidence-case-title').text(title);
 
-    var chart = c3.generate({
+    var data2c3 = {
       bindto: _this.bindTo,
       data: {
         url: url,
@@ -227,11 +227,7 @@ class SRAGIncidenceChart{
         {start: 1, end: _this.lastWeekYears[year], class: 'alert-red'}
       ],*/
       grid: {
-        x: {
-         lines: [
-          {value: week, text: 'Semana Selecionada', position: 'middle'}
-        ], show: false
-        },
+        x: {show: false},
         y: {show: true}
       },
       zoom: {
@@ -249,7 +245,13 @@ class SRAGIncidenceChart{
       legend: {
         position: 'right'
       }
-    });
+    };
+    if (week !== 0) {
+      data2c3.grid.x['lines'] = [
+          {value: week, text: 'Semana Selecionada', position: 'middle'}
+        ];
+    }
+    var chart = c3.generate(data2c3);
 
     this.displayInfo(view_name, dataset, scale, year, week, territoryName);
 

--- a/fludashboard/static/libs/svg-crowbar-2/singledownload-svg-crowbar-2.js
+++ b/fludashboard/static/libs/svg-crowbar-2/singledownload-svg-crowbar-2.js
@@ -1,0 +1,177 @@
+function singleSVGcrowbar(myplot) {
+    var doctype = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
+
+    window.URL = (window.URL || window.webkitURL);
+
+    var body = document.body,
+        emptySvg;
+
+    var prefix = {
+        xmlns: "http://www.w3.org/2000/xmlns/",
+        xlink: "http://www.w3.org/1999/xlink",
+        svg: "http://www.w3.org/2000/svg"
+    };
+
+    initialize(myplot);
+
+    function initialize(myplot) {
+        var documents = [window.document],
+            SVGSources = [];
+        iframes = document.querySelectorAll("iframe"),
+            objects = document.querySelectorAll("object");
+
+        // add empty svg element
+        var emptySvg = window.document.createElementNS(prefix.svg, 'svg');
+        window.document.body.appendChild(emptySvg);
+        var emptySvgDeclarationComputed = getComputedStyle(emptySvg);
+
+        [].forEach.call(iframes, function(el) {
+            try {
+                if (el.contentDocument) {
+                    documents.push(el.contentDocument);
+                }
+            } catch(err) {
+                console.log(err);
+            }
+        });
+
+        [].forEach.call(objects, function(el) {
+            try {
+                if (el.contentDocument) {
+                    documents.push(el.contentDocument);
+                }
+            } catch(err) {
+                console.log(err)
+            }
+        });
+
+        documents.forEach(function(doc) {
+            var newSources = getSources(doc, emptySvgDeclarationComputed);
+            // On our system, we only need the first 4 SVG sources, not all of them:
+            for (var i = 0; i < 4; i++) {
+                SVGSources.push(newSources[i]);
+            }
+        });
+
+        // Define name attribute for SVG, to be used as filename on download function:
+        SVGSources[myplot.SVGid].name = myplot.SVGname;
+        download(SVGSources[myplot.SVGid]);
+    }
+
+
+    function getSources(doc, emptySvgDeclarationComputed) {
+        var svgInfo = [],
+            svgs = doc.querySelectorAll("svg");
+
+        [].forEach.call(svgs, function (svg) {
+
+            svg.setAttribute("version", "1.1");
+
+            // removing attributes so they aren't doubled up
+            svg.removeAttribute("xmlns");
+            svg.removeAttribute("xlink");
+
+            // These are needed for the svg
+            if (!svg.hasAttributeNS(prefix.xmlns, "xmlns")) {
+                svg.setAttributeNS(prefix.xmlns, "xmlns", prefix.svg);
+            }
+
+            if (!svg.hasAttributeNS(prefix.xmlns, "xmlns:xlink")) {
+                svg.setAttributeNS(prefix.xmlns, "xmlns:xlink", prefix.xlink);
+            }
+
+            setInlineStyles(svg, emptySvgDeclarationComputed);
+
+            var source = (new XMLSerializer()).serializeToString(svg);
+            var rect = svg.getBoundingClientRect();
+            svgInfo.push({
+                top: rect.top,
+                left: rect.left,
+                width: rect.width,
+                height: rect.height,
+                class: svg.getAttribute("class"),
+                id: svg.getAttribute("id"),
+                name: svg.getAttribute("name"),
+                childElementCount: svg.childElementCount,
+                source: [doctype + source]
+            });
+        });
+        return svgInfo;
+    }
+
+    function download(source) {
+        var filename = "untitled";
+
+        if (source.name) {
+            filename = source.name;
+        } else if (source.id) {
+            filename = source.id;
+        } else if (source.class) {
+            filename = source.class;
+        } else if (window.document.title) {
+            filename = window.document.title.replace(/[^a-z0-9]/gi, '-').toLowerCase();
+        }
+
+        var url = window.URL.createObjectURL(new Blob(source.source, { "type" : "text\/xml" }));
+
+        var a = document.createElement("a");
+        body.appendChild(a);
+        a.setAttribute("class", "svg-crowbar");
+        a.setAttribute("download", filename + ".svg");
+        a.setAttribute("href", url);
+        a.style["display"] = "none";
+        a.click();
+
+        setTimeout(function() {
+            window.URL.revokeObjectURL(url);
+        }, 10);
+
+        // Reload page after download:
+        window.location.reload();
+    }
+
+
+    function setInlineStyles(svg, emptySvgDeclarationComputed) {
+
+        function explicitlySetStyle (element) {
+            var cSSStyleDeclarationComputed = getComputedStyle(element);
+            var i, len, key, value;
+            var computedStyleStr = "";
+            for (i=0, len=cSSStyleDeclarationComputed.length; i<len; i++) {
+                key=cSSStyleDeclarationComputed[i];
+                value=cSSStyleDeclarationComputed.getPropertyValue(key);
+                if (value!==emptySvgDeclarationComputed.getPropertyValue(key)) {
+                    computedStyleStr+=key+":"+value+";";
+                }
+            }
+            element.setAttribute('style', computedStyleStr);
+        }
+        function traverse(obj){
+            var tree = [];
+            tree.push(obj);
+            visit(obj);
+            function visit(node) {
+                if (node && node.hasChildNodes()) {
+                    var child = node.firstChild;
+                    while (child) {
+                        if (child.nodeType === 1 && child.nodeName != 'SCRIPT'){
+                            tree.push(child);
+                            visit(child);
+                        }
+                        child = child.nextSibling;
+                    }
+                }
+            }
+            return tree;
+        }
+        // hardcode computed css styles inside svg
+        var allElements = traverse(svg);
+        var i = allElements.length;
+        while (i--){
+            explicitlySetStyle(allElements[i]);
+        }
+    }
+
+
+};
+

--- a/fludashboard/templates/index.html
+++ b/fludashboard/templates/index.html
@@ -131,8 +131,10 @@
             Mapa do Plano de Contingência
         </h5>
             <div class="container">
-              <button type="button" class="btn btn-link btn-sm no-print" onclick="getscreenshot('#map-card');">
-                Imprimir imagem</button>
+              <button type="button" class="btn btn-link btn-sm no-print" onclick="getscreenshot(0);">
+                Salvar mapa</button>
+              <button type="button" class="btn btn-link btn-sm no-print" onclick="getscreenshot(1);">
+                Salvar legenda do mapa</button>
             </div>
         <div class="card-block">
           <div id="map" class="content-height"></div>
@@ -142,7 +144,7 @@
       </div>
       <div id="legend">
         <strong id="map-legend-title">N&iacute;vel de ação</strong><br/>
-        <svg width="120" height="90">
+        <svg width="120" height="90" id="map-legend">
           <rect x="10" y="15" height="10" width="10"
                 class="legend-square alert-low"/>
           <text id="map-leg-low" x="20" y="20" transform="translate(8,4)">Nível Basal</text>
@@ -171,8 +173,8 @@
                 <span class="territory-display"></span>
             </h5>
             <div class="container">
-              <button type="button" class="btn btn-link btn-sm no-print" onclick="getscreenshot('#incidence-card');">
-                Imprimir imagem</button>
+              <button type="button" class="btn btn-link btn-sm no-print" onclick="getscreenshot(2);">
+                Salvar imagem</button>
             </div>
             <div class="card-block chart-incidence">
               <!-- info panel -->
@@ -253,8 +255,8 @@
             <span class="territory-display"></span>
         </h5>
         <div class="container">
-          <button type="button" class="btn btn-link btn-sm no-print" onclick="getscreenshot('#age-card');">
-            Imprimir imagem</button>
+          <button type="button" class="btn btn-link btn-sm no-print" onclick="getscreenshot(3);">
+            Salvar imagem</button>
         </div>
         <div class="card-block content-height">
           <div id="age-chart" class="content-height"></div>
@@ -301,7 +303,6 @@
 </div>
 
 <script src="./static/libs/jquery/jquery.js"></script>
-<script src="./static/libs/jquery/jQuery.print.js"></script>
 <script src="./static/libs/bootstrap/bootstrap.min.js"></script>
 <script src="./static/libs/popper/popper.min.js"></script>
 <script src="./static/libs/crossfilter/crossfilter.min.js"></script>
@@ -318,39 +319,17 @@
 <script src="./static/libs/datatables/ext/vfs_fonts.js"></script>
 <script src="./static/libs/datatables/ext/buttons.html5.min.js"></script>
 <script src="./static/libs/plotlyjs/plotly-latest.min.js"></script>
+<script src="./static/libs/svg-crowbar-2/singledownload-svg-crowbar-2.js"></script>
 <script src="./static/js/flu_table.js"></script>
 <script src="./static/js/flu_map.js"></script>
 <script src="./static/js/flu_chart.js"></script>
 <script src="./static/js/dashboard.js"></script>
 <script language="JavaScript" type="text/javascript">
-  function getscreenshot(div) {
-    // Hide row pair:
-    // $('#map-card').addClass('hidden');
+  function getscreenshot(myplot) {
+    var plotName = ['mapa', 'mapa-legenda', 'serie-temporal', 'distribuicao-etaria'];
+    var myplotObj = {SVGid: myplot, SVGname: plotName[myplot]};
 
-    // Temporarily change class attr to spawn all row:
-    var divClass = $(div).attr('class');
-    $(div).attr('class', 'col');
-
-    // ****PROBLEM****
-    // Div size is not upated before calling print()
-    // causing the print to have the size as displayed on user screen
-    // How to refresh it without moving out of this function?
-    // ********
-
-    // jQuery.print solves it in a non-ideal way, since user has to set save as file and so on
-    $(div).print();
-
-
-    // This solution with jsPDF produces **ugly as hell** image:
-    // var pdf = new jsPDF('landscape');
-    // pdf.addHTML(document.getElementById(div), function() {
-    //     pdf.save(name + 'pdf');
-    // });
-
-    // Recover original size after print:
-    // Restore row pair and div original state:
-    // $('#map-card').removeClass('hidden');
-    $(div).attr('class', divClass);
+    singleSVGcrowbar(myplotObj);
   }
 
 </script>


### PR DESCRIPTION
Solution using a modification of svg-crowbar-2.js from https://github.com/NYTimes/svg-crowbar
Modifications:
- Used as a function, not booklet;
- Cycles only up to 4th SVG source, since the remaining ones are not needed;
- Receives SVG sequential number for single plot download;
- Reload page after download.

Bug fix:
- Tweaked flu_chart.js in order to properly hide "selected week" vertical line when not on weekly view mode.